### PR TITLE
Fix float

### DIFF
--- a/API.md
+++ b/API.md
@@ -39,7 +39,7 @@ Sets all module segments to the “dark” state. Clears the internal buffer.
 
 ### `void display(uint32_t number, uint8_t position, uint8_t width, uint8_t flags = SEGM8_ALIGN_RIGHT | SEGM8_RADIX_10)`
 
-### `void display(float number, uint8_t position, uint8_t width, uint8_t precission = 1, uint8_t flags = SEGM8_ALIGN_LEFT)`
+### `void display(double number, uint8_t position, uint8_t width, uint8_t precission = 1, uint8_t flags = SEGM8_ALIGN_LEFT)`
 
 ### `void display(const char* string, uint8_t position, uint8_t width, uint8_t flags = SEGM8_ALIGN_LEFT)`
 

--- a/API_ru.md
+++ b/API_ru.md
@@ -39,7 +39,7 @@
 
 ### `void display(uint32_t number, uint8_t position, uint8_t width, uint8_t flags = SEGM8_ALIGN_RIGHT | SEGM8_RADIX_10)`
 
-### `void display(float number, uint8_t position, uint8_t width, uint8_t precission = 1, uint8_t flags = SEGM8_ALIGN_LEFT)`
+### `void display(double number, uint8_t position, uint8_t width, uint8_t precission = 1, uint8_t flags = SEGM8_ALIGN_LEFT)`
 
 ### `void display(const char* string, uint8_t position, uint8_t width, uint8_t flags = SEGM8_ALIGN_LEFT)`
 

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=SegM8
-version=1.0.0
+version=1.0.1
 author=Amperka <dev@amperka.ru>
 maintainer=Amperka <amperka.ru>
 sentence=A library for giant 7-segment display module.

--- a/src/segm8.cpp
+++ b/src/segm8.cpp
@@ -222,8 +222,20 @@ void SegM8::display(double number, uint8_t position, uint8_t width, uint8_t prec
         };
     }
 
-    if (isNegative && index > 0) // store sign
+    if (isNegative && index > 0) { // store sign
+        if (flags & SEGM8_PAD_ZEROS) {
+            while ((int8_t)(sizeof(_buffer) - 2 - index) < (int8_t)(width - 1)) {
+                _buffer[--index] = '0';
+            }
+        }
         _buffer[--index] = '-';
+    } else {
+        if (flags & SEGM8_PAD_ZEROS) {
+            while ((int8_t)(sizeof(_buffer) - 2 - index) < (int8_t)width) {
+                _buffer[--index] = '0';
+            }
+        }
+    }
 
     display((const char*)&_buffer[index], position, width, flags); // print!
 }

--- a/src/segm8.cpp
+++ b/src/segm8.cpp
@@ -188,7 +188,7 @@ void SegM8::display(uint32_t number, uint8_t position, uint8_t width, uint8_t fl
     }
 }
 
-void SegM8::display(float number, uint8_t position, uint8_t width, uint8_t precission, uint8_t flags) {
+void SegM8::display(double number, uint8_t position, uint8_t width, uint8_t precission, uint8_t flags) {
     for (uint8_t i = 0; i < sizeof(_buffer); i++)
         _buffer[i] = 0;
 

--- a/src/segm8.h
+++ b/src/segm8.h
@@ -51,7 +51,7 @@ public:
 private:
     Spi2Parallel _spi;
     uint8_t _deviceCount;
-    uint8_t _buffer[11];
+    uint8_t _buffer[17];
 };
 
 #endif // __SEGM8_H__

--- a/src/segm8.h
+++ b/src/segm8.h
@@ -40,7 +40,7 @@ public:
         uint8_t flags = SEGM8_ALIGN_RIGHT);
     void display(uint32_t number, uint8_t position, uint8_t width,
         uint8_t flags = SEGM8_ALIGN_RIGHT | SEGM8_RADIX_10);
-    void display(float number, uint8_t position, uint8_t width,
+    void display(double number, uint8_t position, uint8_t width,
         uint8_t precission = 1, uint8_t flags = SEGM8_ALIGN_LEFT);
     void display(const char* string, uint8_t position, uint8_t width,
         uint8_t flags = SEGM8_ALIGN_LEFT);


### PR DESCRIPTION
Fixed a small problem in the API. If you use numbers or variables with display (float number ...), everything works, and if you enter an expression there, the compiler warns that it will not implicitly convert double to float. Replaced float with double.

I also fixed a rare bug. If the length of a float number is less than the length of the field and is simultaneously aligned to the left, the number was displayed incorrectly (the point was in a separate segment). Had to do quite a lot in different places.